### PR TITLE
Added SSL/TLS Support

### DIFF
--- a/PSGELF/Private/New-PSGelfObject.ps1
+++ b/PSGELF/Private/New-PSGelfObject.ps1
@@ -7,6 +7,8 @@
 
         [Parameter(Mandatory)][Int]$Port,
 
+        [Parameter()][switch]$Encrypt,
+
         [Parameter()][String]$HostName,
 
         [Parameter(Mandatory)][String]$ShortMessage,
@@ -26,41 +28,38 @@
         [Parameter()][Hashtable]$AdditionalField
     )
 
-    Begin
-    {
-    }
     Process
     {
-        $Message = New-Object –TypeName PSObject    
+        $Message = New-Object –TypeName PSObject
 
         $Message | Add-Member –MemberType NoteProperty –Name version –Value "1.1"
         $Message | Add-Member –MemberType NoteProperty –Name ShortMessage –Value $ShortMessage
 
-        if (!$HostName) { 
+        if (!$HostName) {
             $HostName = & {hostname}
         }
 
         $Message | Add-Member –MemberType NoteProperty –Name host –Value $HostName
-        
-        if ($FullMessage) { 
-            $Message | Add-Member –MemberType NoteProperty –Name full_message –Value $FullMessage 
+
+        if ($FullMessage) {
+            $Message | Add-Member –MemberType NoteProperty –Name full_message –Value $FullMessage
         }
         if ($DateTime) {
             $TimeStampConversion = Get-Date($DateTime).ToUniversalTime() -uformat "%s"
-            $Message | Add-Member –MemberType NoteProperty –Name timestamp  –Value $TimeStampConversion 
+            $Message | Add-Member –MemberType NoteProperty –Name timestamp  –Value $TimeStampConversion
         }
-        if ($Level ) { 
-            $Message | Add-Member –MemberType NoteProperty –Name level  –Value $Level 
+        if ($Level ) {
+            $Message | Add-Member –MemberType NoteProperty –Name level  –Value $Level
         }
-        if ($Facility) { 
-            $Message | Add-Member –MemberType NoteProperty –Name facility –Value $Facility 
+        if ($Facility) {
+            $Message | Add-Member –MemberType NoteProperty –Name facility –Value $Facility
         }
-        if ($Line) { 
-            $Message | Add-Member –MemberType NoteProperty –Name line –Value $Line 
+        if ($Line) {
+            $Message | Add-Member –MemberType NoteProperty –Name line –Value $Line
         }
 
-        if ($File) { 
-            $Message | Add-Member –MemberType NoteProperty –Name file –Value $File 
+        if ($File) {
+            $Message | Add-Member –MemberType NoteProperty –Name file –Value $File
         }
 
         if ($AdditionalField) {
@@ -79,8 +78,5 @@
         }
 
         Write-Output $Message
-    }
-    End
-    {
     }
 }

--- a/PSGELF/Public/Send-PSGelfTCP.ps1
+++ b/PSGELF/Public/Send-PSGelfTCP.ps1
@@ -5,6 +5,8 @@
    Hostname or IP address of the GELF server to send messages to.
 .PARAMETER Port
    Port number used to communicate with the GELF server.
+.PARAMETER Encrypt
+   Use to use SSL/TLS encryption with the GELF server.
 .PARAMETER HostName
    The name of the host, source or application that sent this message.
 .PARAMETER ShortMessage
@@ -53,6 +55,8 @@ function Send-PSGelfTCP
 
         [Parameter(Mandatory)][Int]$Port,
 
+        [Parameter()][Switch]$Encrypt,
+
         [Parameter()][String]$HostName,
 
         [Parameter(Mandatory)][String]$ShortMessage,
@@ -75,6 +79,6 @@ function Send-PSGelfTCP
     Process
     {
         $GelfMessage = New-PSGelfObject @PsBoundParameters
-        Send-PSGelfTCPFromObject -GelfServer $GelfServer -Port $Port -GelfMessage $GelfMessage
+        Send-PSGelfTCPFromObject -GelfServer $GelfServer -Port $Port -Encrypt:$Encrypt.IsPresent -GelfMessage $GelfMessage
     }
 }

--- a/PSGELF/Public/Send-PSGelfTCP.ps1
+++ b/PSGELF/Public/Send-PSGelfTCP.ps1
@@ -1,6 +1,42 @@
 ﻿<#
 .Synopsis
    Sends a GELF message via TCP.
+.PARAMETER GelfServer
+   Hostname or IP address of the GELF server to send messages to.
+.PARAMETER Port
+   Port number used to communicate with the GELF server.
+.PARAMETER HostName
+   The name of the host, source or application that sent this message.
+.PARAMETER ShortMessage
+   A short descriptive message.
+.PARAMETER FullMessage
+   A long message that can i.e. contain a backtrace.
+.PARAMETER DateTime
+   Timestamp when the event ocurred. Should be set but will default to the
+   current timestamp if absent.
+.PARAMETER Level
+   The level equal to the standard syslog levels - default is 1 (alert)
+
+   0    Emergency
+   1    Alert
+   2    Critical
+   3    Error
+   4    Warning
+   5    Notice
+   6    Informational
+   7    Debug
+.PARAMETER Facility
+   A facility code used to specify the type of program that is logging the
+   message. Deprecated. Send as an additional field instead.
+.PARAMETER Line
+   The line in a file that caused the error (decimal). Deeprecated. Send as an
+   additional field instead.
+.PARAMETER File
+   The file (with path if you want) that caused the error. Deprecated. Send as
+   an additional field instead.
+.PARAMETER AdditionalField
+   Hashtable of additional fields to send. The key will be the additional field
+   name.
 .DESCRIPTION
    This function sends a GELF message via TCP to a server supporting GELF. This function should be used if you don't want to pipe input.
 .EXAMPLE

--- a/PSGELF/Public/Send-PSGelfTCP.ps1
+++ b/PSGELF/Public/Send-PSGelfTCP.ps1
@@ -72,15 +72,9 @@ function Send-PSGelfTCP
         [Parameter()][Hashtable]$AdditionalField
     )
 
-    Begin
-    {
-    }
     Process
     {
         $GelfMessage = New-PSGelfObject @PsBoundParameters
         Send-PSGelfTCPFromObject -GelfServer $GelfServer -Port $Port -GelfMessage $GelfMessage
-    }
-    End
-    {
     }
 }

--- a/PSGELF/Public/Send-PSGelfTCPFromObject.ps1
+++ b/PSGELF/Public/Send-PSGelfTCPFromObject.ps1
@@ -2,7 +2,14 @@
 .Synopsis
    Sends an PSObject to Graylog via TCP.
 .DESCRIPTION
-   This function sends an PSObject to Graylog via TCP to a server supporting GELF. This function should be used if you do want to pipe input.
+   This function sends an PSObject to Graylog via TCP to a server supporting
+   GELF. This function should be used if you do want to pipe input.
+.PARAMETER GelfServer
+   Hostname or IP address of the GELF server to send messages to.
+.PARAMETER Port
+   Port number used to communicate with the GELF server.
+.PARAMETER GelfMessage
+   Message payload to send (from New-PSGelfObject).
 .EXAMPLE
    Get-WinEvent Setup | Send-PSGelfTCPFromObject -GelfServer graylog -Port 12201
 #>
@@ -15,7 +22,7 @@ function Send-PSGelfTCPFromObject
 
         [Parameter(Mandatory)][Int]$Port,
 
-        [Parameter(Mandatory,ValueFromPipeline )][PSCustomObject]$GelfMessage
+        [Parameter(Mandatory,ValueFromPipeline)][PSCustomObject]$GelfMessage
     )
 
     Begin
@@ -24,7 +31,7 @@ function Send-PSGelfTCPFromObject
     Process
     {
         try {
-            
+
             $TcpClient = New-Object System.Net.Sockets.TcpClient
 
             #I am using ConnectAsync because connect isnt supported in .net core

--- a/PSGELF/Public/Send-PSGelfTCPFromObject.ps1
+++ b/PSGELF/Public/Send-PSGelfTCPFromObject.ps1
@@ -13,7 +13,13 @@
 .PARAMETER GelfMessage
    Message payload to send (from New-PSGelfObject).
 .EXAMPLE
+   Send a Windows Event Log to GELF server graylog over port 12201.
+
    Get-WinEvent Setup | Send-PSGelfTCPFromObject -GelfServer graylog -Port 12201
+.EXAMPLE
+   Send a Windows Event Log to GELF server graylog over port 12202 and use SSL/TLS.
+
+   Get-WinEvent Setup | Send-PSGelfTCPFromObject -GelfServer graylog -Port 12202 -Encrypt
 #>
 function Send-PSGelfTCPFromObject
 {

--- a/PSGELF/Public/Send-PSGelfTCPFromObject.ps1
+++ b/PSGELF/Public/Send-PSGelfTCPFromObject.ps1
@@ -25,9 +25,6 @@ function Send-PSGelfTCPFromObject
         [Parameter(Mandatory,ValueFromPipeline)][PSCustomObject]$GelfMessage
     )
 
-    Begin
-    {
-    }
     Process
     {
         try {
@@ -59,8 +56,5 @@ function Send-PSGelfTCPFromObject
         Catch {
             $_
         }
-    }
-    End
-    {
     }
 }

--- a/PSGELF/Public/Send-PSGelfTCPFromObject.ps1
+++ b/PSGELF/Public/Send-PSGelfTCPFromObject.ps1
@@ -43,14 +43,6 @@ function Send-PSGelfTCPFromObject
                 return
             }
 
-            if ($Encrypt.IsPresent) {
-                $SslStream = New-Object System.Net.Security.SslStream $TcpClient.GetStream(), $false, { return $true }, $null
-                $SslStream.AuthenticateAsClient($GelfServer)
-            }
-            else {
-                $TcpStream = $TcpClient.GetStream()
-            }
-
             #Repair-PasGelfObject changes fields names so you can easily pipe Get-WinEvent to this function
             #It also adds and underscore to non default fields.
             $RepairedGelfMessage = Repair-PSGelfObject -GelfMessage $GelfMessage
@@ -60,7 +52,10 @@ function Send-PSGelfTCPFromObject
             #Graylog needs a NULL byte on the end of the data packet
             $ConvertedJSON = $ConvertedJSON + [Byte]0x00
 
+            $TcpStream = $TcpClient.GetStream()
             if ($Encrypt.IsPresent) {
+                $SslStream = New-Object System.Net.Security.SslStream $tcpStream, $false, { return $true }, $null
+                $SslStream.AuthenticateAsClient($GelfServer)
                 $SslStream.Write($ConvertedJSON, 0, $ConvertedJSON.Length)
                 $SslStream.Close()
             }


### PR DESCRIPTION
I added support for SSL/TLS over TCP via an Encrypt parameter on the Send-PSGelfTCP and Send-PSGelfTCPFromObject functions.

```
Send-PSGelfTCP -GelfServer graylog -Port 12202 -Encrypt -ShortMessage "This is a short message"
```