### PR TITLE
UTF8 and short_message

### DIFF
--- a/PSGELF/Private/Repair-PSGelfObject.ps1
+++ b/PSGELF/Private/Repair-PSGelfObject.ps1
@@ -28,12 +28,11 @@
             $GelfMessage = $GelfMessage | Select-Object @{Name="_EventID";Expression={$_."ID"}},* -ExcludeProperty ID
         }
 
-        if($GelfMessage.ShortMessage)
-        {
-            $GelfMessage = $GelfMessage | Select-Object @{Name="short_message";Expression={$_."ShortMessage"}},* -ExcludeProperty ShortMessage
-        }
-        else {
-            if($GelfMessage.Message) {
+        if (!$GelfMessage.short_message) {
+            if($GelfMessage.ShortMessage) {
+                $GelfMessage = $GelfMessage | Select-Object @{Name="short_message";Expression={$_."ShortMessage"}},* -ExcludeProperty ShortMessage
+            }
+            elseif($GelfMessage.Message) {
                 $GelfMessage = $GelfMessage | Select-Object @{Name="short_message";Expression={$_."Message"}},* -ExcludeProperty Message
                 Write-Verbose 'ShortMessage is a required property. The property Message has been renamed ShortMessage to meet the requirments.'
             }

--- a/PSGELF/Public/Send-PSGelfTCPFromObject.ps1
+++ b/PSGELF/Public/Send-PSGelfTCPFromObject.ps1
@@ -51,7 +51,7 @@ function Send-PSGelfTCPFromObject
             #It also adds and underscore to non default fields.
             $RepairedGelfMessage = Repair-PSGelfObject -GelfMessage $GelfMessage
 
-            $ConvertedJSON = [System.Text.Encoding]::ASCII.GetBytes($($RepairedGelfMessage | ConvertTo-Json -Compress))
+            $ConvertedJSON = [System.Text.Encoding]::UTF8.GetBytes($($RepairedGelfMessage | ConvertTo-Json -Compress))
 
             #Graylog needs a NULL byte on the end of the data packet
             $ConvertedJSON = $ConvertedJSON + [Byte]0x00

--- a/PSGELF/Public/Send-PSGelfUDPFromObject.ps1
+++ b/PSGELF/Public/Send-PSGelfUDPFromObject.ps1
@@ -37,7 +37,7 @@ function Send-PSGelfUDPFromObject
         #It also adds and underscore to non default fields.
         $RepairedGelfMessage = Repair-PSGelfObject -GelfMessage $GelfMessage
 
-        $CompressedJSON = [System.Text.Encoding]::ASCII.GetBytes($($RepairedGelfMessage | ConvertTo-Json -Compress))
+        $CompressedJSON = [System.Text.Encoding]::UTF8.GetBytes($($RepairedGelfMessage | ConvertTo-Json -Compress))
 
         #We only need to chunk if the packet is greater than 8192 bytes. 
         #...I left some wiggle room.


### PR DESCRIPTION
1. added UTF8 support.
2. if property "short_message" exist don't throw an error "There must be a ShortMessage or Message property"