### PR TITLE
PowerShell 7 DateTime Precision Fix

### DIFF
--- a/PSGELF/Private/New-PSGelfObject.ps1
+++ b/PSGELF/Private/New-PSGelfObject.ps1
@@ -32,7 +32,7 @@
             $Message | Add-Member –MemberType NoteProperty –Name full_message –Value $FullMessage
         }
         if ($DateTime) {
-            $TimeStampConversion = (Get-Date).ToUniversalTime().Subtract((Get-Date -Year 1970 -Month 1 -Day 1)).TotalSeconds
+            $TimeStampConversion = (Get-Date -Date $DateTime).ToUniversalTime().Subtract((Get-Date -Year 1970 -Month 1 -Day 1)).TotalSeconds
             $Message | Add-Member –MemberType NoteProperty –Name timestamp  –Value $TimeStampConversion
         }
         if ($Level ) {

--- a/PSGELF/Private/New-PSGelfObject.ps1
+++ b/PSGELF/Private/New-PSGelfObject.ps1
@@ -32,7 +32,7 @@
             $Message | Add-Member –MemberType NoteProperty –Name full_message –Value $FullMessage
         }
         if ($DateTime) {
-            $TimeStampConversion = [double]$(Get-Date($DateTime).ToUniversalTime() -uformat "%s")
+            $TimeStampConversion = (Get-Date).ToUniversalTime().Subtract((Get-Date -Year 1970 -Month 1 -Day 1)).TotalSeconds
             $Message | Add-Member –MemberType NoteProperty –Name timestamp  –Value $TimeStampConversion
         }
         if ($Level ) {


### PR DESCRIPTION
This command returns different results between PowerShell 5.1 and 7.

```powershell
Get-Date -Year 2020 -Month 03 -Day 31 -Hour 13 -Minute 28 -Second 13 -Millisecond 134 -UFormat '%s'
```
PowerShell 5.1 Output: `1585661293.134`
PowerShell 7 Output: `1585675693`

This update returns a double data type with 10^-5 precision.